### PR TITLE
renovateのextendの順序変更

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>dev-hato/renovate-config",
-    "config:base"
+    "config:base",
+    "github>dev-hato/renovate-config"
   ]
 }


### PR DESCRIPTION
`dev-hato/renovate-config` を最後に適用する形にすることで、 `dev-hato/renovate-config` の設定が全て適用されるようにします。