### PR TITLE
PRの代わりにsuggestionを出すようにする

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,4 @@ runs:
     - shell: bash
       if: github.event_name != 'pull_request' || github.event.action != 'closed'
       run: bash "${{ github.action_path }}/scripts/action/format.sh"
-    - uses: dev-hato/actions-diff-pr-management@v1.1.6
-      with:
-        github-token: ${{inputs.github-token}}
-        branch-name-prefix: fix-format-json-yml
-        pr-title-prefix: formatが間違ってたので直してあげたよ！
+    - uses: reviewdog/action-suggester@v1


### PR DESCRIPTION
https://github.com/reviewdog/action-suggester を使い、修正点をPRの代わりにsuggestionで示すようにします。
例: https://github.com/dev-hato/actions-format-json-yml/pull/1012#discussion_r1284985535