### PR TITLE
super-linterアップデート・prettierを使う

### DIFF
--- a/.github/workflows/github-actions-cache-cleaner.yml
+++ b/.github/workflows/github-actions-cache-cleaner.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '0 21 * * *' # 06:00 JST
+    - cron: "0 21 * * *" # 06:00 JST
   workflow_dispatch:
 permissions: read-all
 jobs:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -52,7 +52,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v6.9.0
+        uses: super-linter/super-linter/slim@v7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,9 @@
-name: 'format-json-yml'
-author: 'dev-hato Development Team'
-description: 'JSONやYAMLのフォーマットを整える'
+name: "format-json-yml"
+author: "dev-hato Development Team"
+description: "JSONやYAMLのフォーマットを整える"
 inputs:
   github-token: # id of input
-    description: 'GITHUB_TOKEN'
+    description: "GITHUB_TOKEN"
     required: true
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -15,11 +15,11 @@ runs:
       if: github.event_name != 'pull_request' || github.event.action != 'closed'
       with:
         cache: npm
-    - name: Install packages
-      if: github.event_name != 'pull_request' || github.event.action != 'closed'
+    - if: github.event_name != 'pull_request' || github.event.action != 'closed'
       run: npm ci
       shell: bash
     - run: npx prettier --write .
+      if: github.event_name != 'pull_request' || github.event.action != 'closed'
       shell: bash
     - uses: dev-hato/actions-diff-pr-management@v1.1.12
       with:

--- a/action.yml
+++ b/action.yml
@@ -8,13 +8,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - shell: bash
-      if: github.event_name != 'pull_request' || github.event.action != 'closed'
-      run: bash "${{ github.action_path }}/scripts/action/format.sh"
     - uses: actions/setup-node@v4.0.3
       if: github.event_name != 'pull_request' || github.event.action != 'closed'
       with:
         cache: npm
+    - shell: bash
+      if: github.event_name != 'pull_request' || github.event.action != 'closed'
+      run: bash "${{ github.action_path }}/scripts/action/format.sh"
     - if: github.event_name != 'pull_request' || github.event.action != 'closed'
       run: npm ci
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -15,12 +15,12 @@ runs:
     - shell: bash
       if: github.event_name != 'pull_request' || github.event.action != 'closed'
       run: bash "${{ github.action_path }}/scripts/action/format.sh"
-    - if: github.event_name != 'pull_request' || github.event.action != 'closed'
-      run: npm ci
-      shell: bash
-    - run: npx prettier --write .
+    - shell: bash
       if: github.event_name != 'pull_request' || github.event.action != 'closed'
-      shell: bash
+      run: npm ci
+    - shell: bash
+      if: github.event_name != 'pull_request' || github.event.action != 'closed'
+      run: npx prettier --write .
     - uses: dev-hato/actions-diff-pr-management@v1.1.12
       with:
         github-token: ${{inputs.github-token}}

--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,19 @@ runs:
     - shell: bash
       if: github.event_name != 'pull_request' || github.event.action != 'closed'
       run: bash "${{ github.action_path }}/scripts/action/format.sh"
+    - uses: actions/setup-node@v4.0.3
+      if: github.event_name != 'pull_request' || github.event.action != 'closed'
+      with:
+        cache: npm
+    - name: Install packages
+      if: github.event_name != 'pull_request' || github.event.action != 'closed'
+      run: npm ci
+      shell: bash
+    - run: npx prettier --write .
+      shell: bash
     - uses: dev-hato/actions-diff-pr-management@v1.1.12
       with:
         github-token: ${{inputs.github-token}}
         branch-name-prefix: fix-format-json-yml
         pr-title-prefix: formatが間違ってたので直してあげたよ！
+        pr-description-prefix: formatが間違ってたので直してあげたよ！

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@proofdict/textlint-rule-proofdict": "3.1.2",
         "@textlint-ja/textlint-rule-no-insert-dropping-sa": "2.0.1",
+        "prettier": "^3.3.3",
         "textlint": "14.2.0",
         "textlint-filter-rule-comments": "1.2.2",
         "textlint-rule-abbr-within-parentheses": "1.0.2",
@@ -3890,6 +3891,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prh": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "devDependencies": {
     "@proofdict/textlint-rule-proofdict": "3.1.2",
     "@textlint-ja/textlint-rule-no-insert-dropping-sa": "2.0.1",
+    "prettier": "^3.3.3",
     "textlint": "14.2.0",
     "textlint-filter-rule-comments": "1.2.2",
     "textlint-rule-abbr-within-parentheses": "1.0.2",

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>dev-hato/renovate-config"
-  ]
+  "extends": ["github>dev-hato/renovate-config"]
 }


### PR DESCRIPTION
https://github.com/dev-hato/actions-format-json-yml/pull/1391 をベースにsuper-linterをアップデートします。
また、yqコマンドだけでフォーマットを修正すると、prettierとコンフリクトしてsuper-linterが落ちるので、yqコマンド実行後にprettierを実行する形にします。