### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,9 +17,6 @@ runs:
       run: bash "${{ github.action_path }}/scripts/action/format.sh"
     - shell: bash
       if: github.event_name != 'pull_request' || github.event.action != 'closed'
-      run: npm ci
-    - shell: bash
-      if: github.event_name != 'pull_request' || github.event.action != 'closed'
       run: npx prettier --write .
     - uses: dev-hato/actions-diff-pr-management@v1.1.12
       with:


### PR DESCRIPTION
これってなんでいるんだっけ。
https://github.com/dev-hato/hato-atama/actions/runs/10762324488/job/29842517963?pr=4453
hato-atamaでエラーになってる。
hato-atamaは `{"node":"^16.19.0 || ^22.8.0","npm":"^8.19.2 || ^10.8.2"}` を要求してるけど、ここで入っているnodeは `{"npm":"10.7.0","node":"v18.20.4"}` になってる。
setup-nodeをする時に `node-version-file: .node-version` を入れるか、npm ciをなくすのが良さそう？
前者は決め打ちになるので、あんまり良くはなさそうに見えるが、dev-hato配下は全て.node-versionを入れる規約にしてしまうとか、ファイルがない時には指定バージョンを使うとか頑張ればできるかも。
でも、npxしか使ってないし、npm ciする必要がないのであれば消しちゃうのがいいかも。