### PR TITLE
CI format-json-yml: permission修正

### DIFF
--- a/.github/workflows/format-json-yml.yml
+++ b/.github/workflows/format-json-yml.yml
@@ -37,6 +37,7 @@ jobs:
           private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
           permission-contents: write
           permission-pull-requests: write
+          permission-workflows: write
       - uses: ./
         with:
           github-token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
https://github.com/dev-hato/actions-diff-pr-management/actions/runs/28281084107/job/83796848670

```
 ! [remote rejected] HEAD -> fix-format-json-yml-update_super_linter_3 (refusing to allow a GitHub App to create or update workflow `.github/workflows/format-json-yml.yml` without `workflows` permission)
```

上記を防ぐため、permissionを修正します。